### PR TITLE
v1.4 Split ExtendedPersonCard panel into 2

### DIFF
--- a/src/main/java/seedu/address/ui/ExtendedPersonCard.java
+++ b/src/main/java/seedu/address/ui/ExtendedPersonCard.java
@@ -7,7 +7,6 @@ import com.google.common.eventbus.Subscribe;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
@@ -42,8 +41,6 @@ public class ExtendedPersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private Label remark;
-    @FXML
-    private FlowPane tags;
 
     public ExtendedPersonCard() {
         super(FXML);
@@ -62,8 +59,6 @@ public class ExtendedPersonCard extends UiPart<Region> {
         postalCode.setText(person.getPostalCode().toString());
         email.setText(person.getEmail().toString());
         remark.setText(person.getRemark().toString());
-        tags.getChildren().clear();
-        initTags(person);
     }
 
     @Subscribe
@@ -72,15 +67,4 @@ public class ExtendedPersonCard extends UiPart<Region> {
         loadPersonDetails(event.getNewSelection().person);
     }
 
-    /**
-     * Initializes and styles tags belonging to a person.
-     * @param person must be a valid.
-     */
-    protected void initTags(ReadOnlyPerson person) {
-        person.getTags().forEach(tag -> {
-            Label tagLabel = new Label(tag.tagName);
-            tagLabel.setStyle("-fx-font-size:15px");
-            tags.getChildren().add(tagLabel);
-        });
-    }
 }

--- a/src/main/java/seedu/address/ui/ExtendedPersonCard.java
+++ b/src/main/java/seedu/address/ui/ExtendedPersonCard.java
@@ -1,16 +1,11 @@
 package seedu.address.ui;
 
-import java.util.Comparator;
 import java.util.logging.Logger;
 
 import com.google.common.eventbus.Subscribe;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.chart.CategoryAxis;
-import javafx.scene.chart.LineChart;
-import javafx.scene.chart.NumberAxis;
-import javafx.scene.chart.XYChart;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
@@ -28,16 +23,9 @@ public class ExtendedPersonCard extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(this.getClass());
 
     private ObservableList<ReadOnlyPerson> people;
-    private XYChart.Series<String, Double> series = new XYChart.Series<>();
 
     @FXML
     private HBox cardpane;
-    @FXML
-    private CategoryAxis xNameAxis;
-    @FXML
-    private NumberAxis yGradeAxis;
-    @FXML
-    private LineChart<String, Double> lineChart;
     @FXML
     private Label name;
     @FXML
@@ -57,9 +45,8 @@ public class ExtendedPersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
 
-    public ExtendedPersonCard(ObservableList<ReadOnlyPerson> personList) {
+    public ExtendedPersonCard() {
         super(FXML);
-        this.people = personList;
         registerAsAnEventHandler(this);
     }
 
@@ -79,44 +66,10 @@ public class ExtendedPersonCard extends UiPart<Region> {
         initTags(person);
     }
 
-    /**
-     * Displays statistics of @param person according to class
-     */
-    private void displayGraphStats (ReadOnlyPerson person) {
-        xNameAxis.setLabel("Student Names");
-        yGradeAxis.setLabel("Grades");
-        lineChart.setTitle(person.getFormClass().toString());
-        lineChart.layout();
-        lineChart.setAnimated(false);
-
-        for (ReadOnlyPerson people : people) {
-            if (people.getFormClass().equals(person.getFormClass())) {
-                series.getData().add(new XYChart.Data<>(people.getName().toString(),
-                        Double.parseDouble(people.getGrades().toString())));
-            }
-        }
-
-        try {
-            series.getData().sort(Comparator.comparingDouble(d -> d.getYValue()));
-        } catch (NullPointerException e) {
-            throw new NullPointerException();
-        }
-        lineChart.getData().add(series);
-        lineChart.setLegendVisible(false);
-
-    }
-
-
-    private void resetGraphStats() {
-        series.getData().clear();
-    }
-
     @Subscribe
     private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         loadPersonDetails(event.getNewSelection().person);
-        resetGraphStats();
-        displayGraphStats(event.getNewSelection().person);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/GraphPanel.java
+++ b/src/main/java/seedu/address/ui/GraphPanel.java
@@ -1,0 +1,81 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+import java.util.logging.Logger;
+
+import com.google.common.eventbus.Subscribe;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
+import seedu.address.model.person.ReadOnlyPerson;
+
+/**
+ * Displays the specified graphs that the user wants
+ */
+public class GraphPanel extends UiPart<Region> {
+
+
+    private static final String FXML = "GraphPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(this.getClass());
+
+    private ObservableList<ReadOnlyPerson> people;
+    private XYChart.Series<String, Double> series = new XYChart.Series<>();
+
+    @FXML
+    private CategoryAxis xNameAxis;
+    @FXML
+    private NumberAxis yGradeAxis;
+    @FXML
+    private LineChart<String, Double> lineChart;
+
+    public GraphPanel(ObservableList<ReadOnlyPerson> personList) {
+        super(FXML);
+        this.people = personList;
+        registerAsAnEventHandler(this);
+    }
+
+    /**
+     * Displays statistics of @param person according to class
+     */
+    private void displayGraphStats (ReadOnlyPerson person) {
+        xNameAxis.setLabel("Student Names");
+        yGradeAxis.setLabel("Grades");
+        lineChart.setTitle(person.getFormClass().toString());
+        lineChart.layout();
+        lineChart.setAnimated(false);
+
+        for (ReadOnlyPerson people : people) {
+            if (people.getFormClass().equals(person.getFormClass())) {
+                series.getData().add(new XYChart.Data<>(people.getName().toString(),
+                        Double.parseDouble(people.getGrades().toString())));
+            }
+        }
+
+        try {
+            series.getData().sort(Comparator.comparingDouble(d -> d.getYValue()));
+        } catch (NullPointerException e) {
+            throw new NullPointerException();
+        }
+        lineChart.getData().add(series);
+        lineChart.setLegendVisible(false);
+    }
+
+
+    private void resetGraphStats() {
+        series.getData().clear();
+    }
+
+    @Subscribe
+    private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        resetGraphStats();
+        displayGraphStats(event.getNewSelection().person);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -40,15 +40,11 @@ public class MainWindow extends UiPart<Region> {
     private Logic logic;
 
     // Independent Ui parts residing in this Ui container
-    private BrowserPanel browserPanel;
     private ExtendedPersonCard extendedPersonCard;
     private GraphPanel graphPanel;
     private PersonListPanel personListPanel;
     private Config config;
     private UserPrefs prefs;
-
-    @FXML
-    private StackPane browserPlaceholder;
 
     @FXML
     private StackPane extendedPersonCardPlaceholder;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -42,6 +42,7 @@ public class MainWindow extends UiPart<Region> {
     // Independent Ui parts residing in this Ui container
     private BrowserPanel browserPanel;
     private ExtendedPersonCard extendedPersonCard;
+    private GraphPanel graphPanel;
     private PersonListPanel personListPanel;
     private Config config;
     private UserPrefs prefs;
@@ -54,6 +55,9 @@ public class MainWindow extends UiPart<Region> {
 
     @FXML
     private StackPane commandBoxPlaceholder;
+
+    @FXML
+    private StackPane graphPanelPlaceholder;
 
     @FXML
     private MenuItem helpMenuItem;
@@ -133,8 +137,11 @@ public class MainWindow extends UiPart<Region> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        extendedPersonCard = new ExtendedPersonCard(logic.getFilteredPersonList());
+        extendedPersonCard = new ExtendedPersonCard();
         extendedPersonCardPlaceholder.getChildren().add(extendedPersonCard.getRoot());
+
+        GraphPanel graphPanel = new GraphPanel(logic.getFilteredPersonList());
+        graphPanelPlaceholder.getChildren().add(graphPanel.getRoot());
 
         ResultDisplay resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -214,6 +221,10 @@ public class MainWindow extends UiPart<Region> {
 
     public ExtendedPersonCard getExtendedPersonCard() {
         return this.extendedPersonCard;
+    }
+
+    public GraphPanel getGraphPanel() {
+        return this.graphPanel;
     }
 
     @Subscribe

--- a/src/main/resources/view/ExtendedPersonCard.fxml
+++ b/src/main/resources/view/ExtendedPersonCard.fxml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.chart.CategoryAxis?>
-<?import javafx.scene.chart.LineChart?>
-<?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
@@ -110,18 +106,5 @@
         <rowConstraints>
             <RowConstraints />
         </rowConstraints>
-    </GridPane>
-    <GridPane minWidth="600">
-   <AnchorPane prefHeight="200.0" prefWidth="200.0">
-      <children>
-         <LineChart fx:id="lineChart" layoutY="10.0" maxHeight="1.5" maxWidth="1.5" minHeight="500" minWidth="700" prefHeight="600" prefWidth="800.0">
-           <xAxis>
-             <CategoryAxis minHeight="400.0" minWidth="400.0" side="BOTTOM" fx:id="xNameAxis" />
-           </xAxis>
-           <yAxis>
-             <NumberAxis fx:id="yGradeAxis" side="LEFT" tickLabelFill="#ffffff2e" />
-           </yAxis>
-         </LineChart>
-      </children></AnchorPane>
     </GridPane>
 </HBox>

--- a/src/main/resources/view/ExtendedPersonCard.fxml
+++ b/src/main/resources/view/ExtendedPersonCard.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
@@ -98,7 +97,6 @@
                   </image>
                </ImageView>
             </graphic></Label>
-            <FlowPane fx:id="tags" alignment="BASELINE_LEFT" />
          <GridPane.margin>
             <Insets />
          </GridPane.margin>

--- a/src/main/resources/view/GraphPanel.fxml
+++ b/src/main/resources/view/GraphPanel.fxml
@@ -2,15 +2,15 @@
 
 <?import javafx.scene.layout.*?>
 
-<?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.CategoryAxis?>
+<?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
-<AnchorPane xmlns="http://javafx.com/javafx"
-            xmlns:fx="http://javafx.com/fxml"
-            prefHeight="400.0" prefWidth="600.0">
+<?import javafx.scene.layout.AnchorPane?>
+
+<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1">
 
         <children>
-            <LineChart fx:id="graphPanel" layoutY="10.0" maxHeight="1.5" maxWidth="1.5" minHeight="500" minWidth="600" prefHeight="600" prefWidth="800.0">
+            <LineChart fx:id="lineChart" layoutY="10.0" maxHeight="1.5" maxWidth="1.5" minHeight="500" minWidth="600" prefHeight="600" prefWidth="800.0">
                 <xAxis>
                     <CategoryAxis minHeight="400.0" minWidth="400.0" side="BOTTOM" fx:id="xNameAxis" />
                 </xAxis>

--- a/src/main/resources/view/GraphPanel.fxml
+++ b/src/main/resources/view/GraphPanel.fxml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.*?>
+
+<?import javafx.scene.chart.LineChart?>
+<?import javafx.scene.chart.CategoryAxis?>
+<?import javafx.scene.chart.NumberAxis?>
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            prefHeight="400.0" prefWidth="600.0">
+
+        <children>
+            <LineChart fx:id="graphPanel" layoutY="10.0" maxHeight="1.5" maxWidth="1.5" minHeight="500" minWidth="600" prefHeight="600" prefWidth="800.0">
+                <xAxis>
+                    <CategoryAxis minHeight="400.0" minWidth="400.0" side="BOTTOM" fx:id="xNameAxis" />
+                </xAxis>
+                <yAxis>
+                    <NumberAxis fx:id="yGradeAxis" side="LEFT" tickLabelFill="#ffffff2e" />
+                </yAxis>
+            </LineChart>
+        </children>
+
+</AnchorPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -50,6 +50,12 @@
         <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
     </StackPane>
+
+    <StackPane fx:id="graphPanelPlaceholder" prefWidth="340" >
+      <padding>
+        <Insets top="10" right="10" bottom="10" left="10" />
+      </padding>
+    </StackPane>
   </SplitPane>
 
   <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -11,6 +11,7 @@ import org.testfx.api.FxToolkit;
 
 import guitests.guihandles.CommandBoxHandle;
 import guitests.guihandles.ExtendedPersonCardHandle;
+import guitests.guihandles.GraphPanelHandle;
 import guitests.guihandles.MainMenuHandle;
 import guitests.guihandles.MainWindowHandle;
 import guitests.guihandles.PersonListPanelHandle;
@@ -81,6 +82,10 @@ public abstract class AddressBookGuiTest {
 
     protected ExtendedPersonCardHandle getExtendedPersonCard() {
         return mainWindowHandle.getExtendedPersonCard();
+    }
+
+    protected GraphPanelHandle getGraphPanel() {
+        return mainWindowHandle.getGraphPanel();
     }
 
     protected StatusBarFooterHandle getStatusBarFooter() {

--- a/src/test/java/guitests/HelpWindowTest.java
+++ b/src/test/java/guitests/HelpWindowTest.java
@@ -33,6 +33,10 @@ public class HelpWindowTest extends AddressBookGuiTest {
         getMainMenu().openHelpWindowUsingAccelerator();
         assertHelpWindowOpen();
 
+        getGraphPanel().click();
+        getMainMenu().openHelpWindowUsingAccelerator();
+        assertHelpWindowOpen();
+
         //use menu button
         getMainMenu().openHelpWindowUsingMenu();
         assertHelpWindowOpen();

--- a/src/test/java/guitests/guihandles/ExtendedPersonCardHandle.java
+++ b/src/test/java/guitests/guihandles/ExtendedPersonCardHandle.java
@@ -1,11 +1,7 @@
 package guitests.guihandles;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.layout.Region;
 
 /**
  * Provides a handle to a person card in the person list panel.
@@ -21,7 +17,6 @@ public class ExtendedPersonCardHandle extends NodeHandle<Node> {
     private static final String GRADES_FIELD_ID = "#grades";
     private static final String POSTALCODE_FIELD_ID = "#postalCode";
     private static final String REMARK_FIELD_ID = "#remark";
-    private static final String TAGS_FIELD_ID = "#tags";
 
 
     private final Label idLabel;
@@ -33,7 +28,6 @@ public class ExtendedPersonCardHandle extends NodeHandle<Node> {
     private final Label gradesLabel;
     private final Label postalCodeLabel;
     private final Label remarkLabel;
-    private final List<Label> tagLabels;
 
 
     public ExtendedPersonCardHandle(Node cardNode) {
@@ -48,13 +42,6 @@ public class ExtendedPersonCardHandle extends NodeHandle<Node> {
         this.postalCodeLabel = getChildNode(POSTALCODE_FIELD_ID);
         this.emailLabel = getChildNode(EMAIL_FIELD_ID);
         this.remarkLabel = getChildNode(REMARK_FIELD_ID);
-
-        Region tagsContainer = getChildNode(TAGS_FIELD_ID);
-        this.tagLabels = tagsContainer
-                .getChildrenUnmodifiable()
-                .stream()
-                .map(Label.class::cast)
-                .collect(Collectors.toList());
     }
 
     public String getId() {
@@ -91,12 +78,5 @@ public class ExtendedPersonCardHandle extends NodeHandle<Node> {
 
     public String getRemark() {
         return remarkLabel.getText();
-    }
-
-    public List<String> getTags() {
-        return tagLabels
-                .stream()
-                .map(Label::getText)
-                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/guitests/guihandles/GraphPanelHandle.java
+++ b/src/test/java/guitests/guihandles/GraphPanelHandle.java
@@ -1,15 +1,24 @@
 package guitests.guihandles;
 
-import javafx.scene.control.TextArea;
+import javafx.scene.Node;
+import seedu.address.model.person.ReadOnlyPerson;
 
 /**
  * Provides a handle to the graph of a person in the person list panel.
  */
-public class GraphPanelHandle extends NodeHandle<TextArea> {
+public class GraphPanelHandle extends NodeHandle<Node> {
 
     public static final String GRAPH_DISPLAY_ID = "#graphPanelPlaceholder";
+    private ReadOnlyPerson person;
 
-    public GraphPanelHandle(TextArea graphPanelNode) {
+    public GraphPanelHandle(Node graphPanelNode) {
         super(graphPanelNode);
+    }
+
+    /**
+     * Returns the graph in the graph panel display.
+     */
+    public void getGraph() {
+    // TODO: get the graph of the person
     }
 }

--- a/src/test/java/guitests/guihandles/GraphPanelHandle.java
+++ b/src/test/java/guitests/guihandles/GraphPanelHandle.java
@@ -8,7 +8,7 @@ import seedu.address.model.person.ReadOnlyPerson;
  */
 public class GraphPanelHandle extends NodeHandle<Node> {
 
-    public static final String GRAPH_DISPLAY_ID = "#graphPanelPlaceholder";
+    public static final String GRAPH_DISPLAY_ID = "#lineChart";
     private ReadOnlyPerson person;
 
     public GraphPanelHandle(Node graphPanelNode) {

--- a/src/test/java/guitests/guihandles/GraphPanelHandle.java
+++ b/src/test/java/guitests/guihandles/GraphPanelHandle.java
@@ -1,0 +1,15 @@
+package guitests.guihandles;
+
+import javafx.scene.control.TextArea;
+
+/**
+ * Provides a handle to the graph of a person in the person list panel.
+ */
+public class GraphPanelHandle extends NodeHandle<TextArea> {
+
+    public static final String GRAPH_DISPLAY_ID = "#graphPanelPlaceholder";
+
+    public GraphPanelHandle(TextArea graphPanelNode) {
+        super(graphPanelNode);
+    }
+}

--- a/src/test/java/guitests/guihandles/MainWindowHandle.java
+++ b/src/test/java/guitests/guihandles/MainWindowHandle.java
@@ -52,6 +52,6 @@ public class MainWindowHandle extends StageHandle {
         return extendedPersonCard;
     }
 
-    public GraphPanelHandle getGraphPanel() { return graphPanel;
-    }
+    public GraphPanelHandle getGraphPanel() {
+        return graphPanel; }
 }

--- a/src/test/java/guitests/guihandles/MainWindowHandle.java
+++ b/src/test/java/guitests/guihandles/MainWindowHandle.java
@@ -13,6 +13,7 @@ public class MainWindowHandle extends StageHandle {
     private final StatusBarFooterHandle statusBarFooter;
     private final MainMenuHandle mainMenu;
     private final ExtendedPersonCardHandle extendedPersonCard;
+    private final GraphPanelHandle graphPanel;
 
     public MainWindowHandle(Stage stage) {
         super(stage);
@@ -20,6 +21,7 @@ public class MainWindowHandle extends StageHandle {
         personListPanel = new PersonListPanelHandle(getChildNode(PersonListPanelHandle.PERSON_LIST_VIEW_ID));
         extendedPersonCard = new ExtendedPersonCardHandle(getChildNode(ExtendedPersonCardHandle
                 .EXTENDED_PERSON_CARD_ID));
+        graphPanel = new GraphPanelHandle(getChildNode(GraphPanelHandle.GRAPH_DISPLAY_ID));
         resultDisplay = new ResultDisplayHandle(getChildNode(ResultDisplayHandle.RESULT_DISPLAY_ID));
         commandBox = new CommandBoxHandle(getChildNode(CommandBoxHandle.COMMAND_INPUT_FIELD_ID));
         statusBarFooter = new StatusBarFooterHandle(getChildNode(StatusBarFooterHandle.STATUS_BAR_PLACEHOLDER));
@@ -48,5 +50,8 @@ public class MainWindowHandle extends StageHandle {
 
     public ExtendedPersonCardHandle getExtendedPersonCard() {
         return extendedPersonCard;
+    }
+
+    public GraphPanelHandle getGraphPanel() { return graphPanel;
     }
 }

--- a/src/test/java/seedu/address/ui/ExtendedPersonCardTest.java
+++ b/src/test/java/seedu/address/ui/ExtendedPersonCardTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.EventsUtil.postNow;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardDisplaysPerson;
 
 import java.util.stream.Collectors;
@@ -16,24 +15,19 @@ import org.junit.Test;
 
 import guitests.guihandles.ExtendedPersonCardHandle;
 import javafx.application.Platform;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.testutil.PersonBuilder;
 
 public class ExtendedPersonCardTest extends GuiUnitTest {
-
-    private static final ObservableList<ReadOnlyPerson> TYPICAL_PERSONS =
-            FXCollections.observableList(getTypicalPersons());
     private ExtendedPersonCard extendedPersonCard;
     private ExtendedPersonCardHandle extendedPersonCardHandle;
 
     @Before
     public void setUp() {
         try {
-            guiRobot.interact(() -> extendedPersonCard = new ExtendedPersonCard(TYPICAL_PERSONS));
+            guiRobot.interact(() -> extendedPersonCard = new ExtendedPersonCard());
             uiPartRule.setUiPart(extendedPersonCard);
             extendedPersonCardHandle = new ExtendedPersonCardHandle(extendedPersonCard.getRoot());
         } catch (NullPointerException e) {

--- a/src/test/java/seedu/address/ui/ExtendedPersonCardTest.java
+++ b/src/test/java/seedu/address/ui/ExtendedPersonCardTest.java
@@ -8,13 +8,10 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardDisplaysPerson;
 
-import java.util.stream.Collectors;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import guitests.guihandles.ExtendedPersonCardHandle;
-import javafx.application.Platform;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -58,24 +55,7 @@ public class ExtendedPersonCardTest extends GuiUnitTest {
         assertEquals(expectedPerson.getPostalCode().toString(), extendedPersonCardHandle.getPostalCode());
         assertEquals(expectedPerson.getEmail().toString(), extendedPersonCardHandle.getEmail());
         assertEquals(expectedPerson.getRemark().toString(), extendedPersonCardHandle.getRemark());
-
-        //update tag information displayed
-        Platform.runLater((Runnable) () -> {
-            extendedPersonCard.loadPersonDetails(expectedPerson);
-            assertTagsDisplayed(expectedPerson, extendedPersonCardHandle);
-        });
-
     }
-
-    /*
-     * If {@code extended person card} displays tags of {@code expectedPerson} --> returns true
-     */
-    private void assertTagsDisplayed(ReadOnlyPerson expectedPerson, ExtendedPersonCardHandle
-            extendedPersonCardHandleHandle) {
-        assertEquals(expectedPerson.getTags().stream().map(tag -> tag.tagName).collect(Collectors.toList()),
-                extendedPersonCardHandle.getTags());
-    }
-
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/ui/GraphPanelTest.java
+++ b/src/test/java/seedu/address/ui/GraphPanelTest.java
@@ -20,7 +20,6 @@ public class GraphPanelTest extends GuiUnitTest {
 
     private static final ObservableList<ReadOnlyPerson> TYPICAL_PERSONS =
             FXCollections.observableList(getTypicalPersons());
-    private PersonPanelSelectionChangedEvent selectionChangedEventStub;
 
     private GraphPanel graphPanel;
     private GraphPanelHandle graphPanelHandle;
@@ -30,7 +29,7 @@ public class GraphPanelTest extends GuiUnitTest {
         try {
             guiRobot.interact(() -> graphPanel = new GraphPanel(TYPICAL_PERSONS));
             uiPartRule.setUiPart(graphPanel);
-            graphPanel = new GraphPanelHandle(graphPanel.getRoot());
+            graphPanelHandle = new GraphPanelHandle(graphPanel.getRoot());
         } catch (NullPointerException e) {
             throw new NullPointerException();
         }
@@ -39,16 +38,8 @@ public class GraphPanelTest extends GuiUnitTest {
     @Test
     public void display() throws Exception {
         // select ALICE
-        postNow(new PersonPanelSelectionChangedEvent(new PersonCard(ALICE, 0)));
-        assertGraphIsDisplayed(ALICE, graphPanelHandle);
+        postNow(new PersonPanelSelectionChangedEvent(new PersonCard(ALICE, 0)));;
         // select BOB
         postNow(new PersonPanelSelectionChangedEvent(new PersonCard(BOB, 1)));
-        assertGraphIsDisplayed(BOB, graphPanelHandle);
-
-    }
-
-    // ======================================= HELPER METHOD ============================================
-    private void assertGraphIsDisplayed(ReadOnlyPerson alice, GraphPanelHandle graphPanelHandle) {
-        // TODO: Add test
     }
 }

--- a/src/test/java/seedu/address/ui/GraphPanelTest.java
+++ b/src/test/java/seedu/address/ui/GraphPanelTest.java
@@ -1,0 +1,54 @@
+package seedu.address.ui;
+
+import static seedu.address.testutil.EventsUtil.postNow;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import guitests.guihandles.GraphPanelHandle;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
+import seedu.address.model.person.ReadOnlyPerson;
+
+public class GraphPanelTest extends GuiUnitTest {
+
+    private static final ObservableList<ReadOnlyPerson> TYPICAL_PERSONS =
+            FXCollections.observableList(getTypicalPersons());
+    private PersonPanelSelectionChangedEvent selectionChangedEventStub;
+
+    private GraphPanel graphPanel;
+    private GraphPanelHandle graphPanelHandle;
+
+    @Before
+    public void setUp() {
+        try {
+            guiRobot.interact(() -> graphPanel = new GraphPanel(TYPICAL_PERSONS));
+            uiPartRule.setUiPart(graphPanel);
+            graphPanel = new GraphPanelHandle(graphPanel.getRoot());
+        } catch (NullPointerException e) {
+            throw new NullPointerException();
+        }
+    }
+
+    @Test
+    public void display() throws Exception {
+        // select ALICE
+        postNow(new PersonPanelSelectionChangedEvent(new PersonCard(ALICE, 0)));
+        assertGraphIsDisplayed(ALICE, graphPanelHandle);
+        // select BOB
+        postNow(new PersonPanelSelectionChangedEvent(new PersonCard(BOB, 1)));
+        assertGraphIsDisplayed(BOB, graphPanelHandle);
+
+    }
+
+    // ======================================= HELPER METHOD ============================================
+    private void assertGraphIsDisplayed(ReadOnlyPerson alice, GraphPanelHandle graphPanelHandle) {
+        // TODO: Add test
+    }
+}

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -45,7 +45,6 @@ public class GuiTestAssert {
         assertEquals(expectedPerson.getPostalCode().value, actualCard.getPostalCode());
         assertEquals(expectedPerson.getEmail().value, actualCard.getEmail());
         assertEquals(expectedPerson.getRemark().value, actualCard.getRemark());
-        assertEquals(expectedPerson.getTags().stream(), actualCard.getTags());
     }
 
     /**

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -21,6 +21,7 @@ import org.junit.ClassRule;
 
 import guitests.guihandles.CommandBoxHandle;
 import guitests.guihandles.ExtendedPersonCardHandle;
+import guitests.guihandles.GraphPanelHandle;
 import guitests.guihandles.MainMenuHandle;
 import guitests.guihandles.MainWindowHandle;
 import guitests.guihandles.PersonListPanelHandle;
@@ -85,6 +86,10 @@ public abstract class AddressBookSystemTest {
 
     public ExtendedPersonCardHandle getExtendedPersonCard() {
         return mainWindowHandle.getExtendedPersonCard();
+    }
+
+    public GraphPanelHandle getGraphPanel() {
+        return mainWindowHandle.getGraphPanel();
     }
 
     public StatusBarFooterHandle getStatusBarFooter() {


### PR DESCRIPTION
1. Split ExtendedPersonCard panel into 2 different panels containing person's information panel and graph panel
2. Removed tags from ExtendedPersonCard and relevant tests